### PR TITLE
Add minimal market cap dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
-# projectMC
+# Market Cap Dashboard
+
+This repository contains a minimal implementation of a market capitalization dashboard inspired by **8marketcap.com**.
+
+## Structure
+
+- `backend` – Node.js server exposing an `/api/assets` endpoint and serving the frontend files.
+- `frontend` – Static files (HTML/CSS/JS) that fetch and display asset data.
+
+## Running the project
+
+1. `cd backend`
+2. Install dependencies (none required).
+3. Run the server:
+   ```bash
+   node server.js
+   ```
+4. Open `http://localhost:3000` in your browser.
+
+## Tests
+
+From the `backend` directory run:
+
+```bash
+npm test
+```
+
+This uses Node's built-in test runner to verify that the API returns data.

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "backend",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "node --test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,0 +1,54 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const assets = [
+  { id: 1, symbol: 'BTC', name: 'Bitcoin', price: 30000, marketCap: 600000000000 },
+  { id: 2, symbol: 'ETH', name: 'Ethereum', price: 2000, marketCap: 240000000000 },
+  { id: 3, symbol: 'DOGE', name: 'Dogecoin', price: 0.1, marketCap: 14000000000 }
+];
+
+function serveStatic(filePath, res) {
+  const abs = path.join(__dirname, '..', 'frontend', filePath);
+  fs.readFile(abs, (err, data) => {
+    if (err) {
+      res.statusCode = 404;
+      res.end('Not found');
+    } else {
+      if (filePath.endsWith('.css')) res.setHeader('Content-Type', 'text/css');
+      if (filePath.endsWith('.js')) res.setHeader('Content-Type', 'application/javascript');
+      res.end(data);
+    }
+  });
+}
+
+const server = http.createServer((req, res) => {
+  if (req.url === '/api/assets') {
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify(assets));
+    return;
+  }
+
+  if (req.url === '/' || req.url === '/index.html') {
+    serveStatic('index.html', res);
+    return;
+  }
+
+  if (req.url === '/script.js') {
+    serveStatic('script.js', res);
+    return;
+  }
+
+  if (req.url === '/styles.css') {
+    serveStatic('styles.css', res);
+    return;
+  }
+
+  res.statusCode = 404;
+  res.end('Not found');
+});
+
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, () => {
+  console.log(`Server running on http://localhost:${PORT}`);
+});

--- a/backend/tests/server.test.js
+++ b/backend/tests/server.test.js
@@ -1,0 +1,43 @@
+const test = require('node:test');
+const assert = require('assert');
+const http = require('http');
+const { spawn } = require('child_process');
+const path = require('path');
+
+const serverPath = path.join(__dirname, '..', 'server.js');
+const PORT = 3100;
+
+let serverProcess;
+
+test.before(async () => {
+  await new Promise((resolve) => {
+    serverProcess = spawn(process.execPath, [serverPath], { env: { ...process.env, PORT } });
+    serverProcess.stdout.on('data', data => {
+      if (data.toString().includes(`http://localhost:${PORT}`)) {
+        resolve();
+      }
+    });
+  });
+});
+
+test.after(() => {
+  serverProcess.kill();
+});
+
+test('returns asset data', async (t) => {
+  await new Promise((resolve, reject) => {
+    http.get(`http://localhost:${PORT}/api/assets`, res => {
+      let data = '';
+      res.on('data', chunk => data += chunk);
+      res.on('end', () => {
+        try {
+          const json = JSON.parse(data);
+          assert(Array.isArray(json));
+          resolve();
+        } catch (err) {
+          reject(err);
+        }
+      });
+    }).on('error', reject);
+  });
+});

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Market Cap Dashboard</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <h1>Market Cap Dashboard</h1>
+  <table id="assets">
+    <thead>
+      <tr><th>Symbol</th><th>Name</th><th>Price</th><th>Market Cap</th></tr>
+    </thead>
+    <tbody></tbody>
+  </table>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -1,0 +1,11 @@
+fetch('/api/assets')
+  .then(res => res.json())
+  .then(data => {
+    const tbody = document.querySelector('#assets tbody');
+    data.forEach(asset => {
+      const row = document.createElement('tr');
+      row.innerHTML = `<td>${asset.symbol}</td><td>${asset.name}</td><td>$${asset.price}</td><td>$${asset.marketCap}</td>`;
+      tbody.appendChild(row);
+    });
+  })
+  .catch(err => console.error(err));

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1,0 +1,5 @@
+body { font-family: Arial, sans-serif; padding: 20px; }
+
+table { border-collapse: collapse; width: 100%; }
+
+th, td { border: 1px solid #ccc; padding: 8px; text-align: left; }


### PR DESCRIPTION
## Summary
- set up a simple Node.js server serving an API and static frontend
- display sample asset data in the browser
- include a basic test for the `/api/assets` endpoint
- document how to run the project

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68730ba1358c8333997d05d01e4b85cc